### PR TITLE
Identifying things with clear Manchester copyright ownership

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,13 +49,13 @@
 				<configuration>
 					<useDefaultExcludes>true</useDefaultExcludes>
 					<excludes>
-					    <!-- Following excludes needed for taverna-scufl2-rdf,
-					    taverna-scufl2-integration-tests and taverna-scufl2-validation-integration
-					    subfolders that should be modules but are not. -->
-					    <exclude>**/.classpath</exclude>
-					    <exclude>**/.project</exclude>
-					    <exclude>**/.settings/</exclude>
-					    <exclude>**/target/</exclude>
+						<!-- Following excludes needed for taverna-scufl2-rdf,
+						taverna-scufl2-integration-tests and taverna-scufl2-validation-integration
+						subfolders that should be modules but are not. -->
+						<exclude>**/.classpath</exclude>
+						<exclude>**/.project</exclude>
+						<exclude>**/.settings/</exclude>
+						<exclude>**/target/</exclude>
 						<!-- Text and Markdown files are typically used only for documentation 
 							purposes and license declarations are usually spurious in these files since 
 							often they will refer to the LICENSE/NOTICE for users to find the actual 
@@ -64,8 +64,8 @@
 						<!-- META-INF services files can include comments but a license header 
 							would be unecessarily clutter so we exclude these -->
 						<exclude>**/META-INF/services/*</exclude>
-			            <!-- No headers in JSON which haven't got comments ... -->
-            			<exclude>**/*.json</exclude>
+						<!-- No headers in JSON which haven't got comments ... -->
+						<exclude>**/*.json</exclude>
 						<!-- Really a binary format, but must look like text -->
 						<exclude>**/mimetype</exclude>
 						<!-- Effectively a binary format -->
@@ -96,36 +96,36 @@
 						<exclude>/src/test/resources/t172starterpacklist</exclude>
 						<exclude>/src/test/resources/t230starterpacklist</exclude>
 						<!-- THESE ARE XML AND SUPPORT COMMENTS -->
-            			<exclude>/src/test/resources/annotation_with_backslash.t2flow</exclude>
-            			<exclude>/src/test/resources/beanshell-deps.t2flow</exclude>
-            			<exclude>/src/test/resources/component_simple.t2flow</exclude>
-            			<exclude>/src/test/resources/dataflow_link_then_merge.t2flow</exclude>
-            			<exclude>/src/test/resources/dispatchlayers-xsd.t2flow</exclude>
-            			<exclude>/src/test/resources/dispatchlayers.t2flow</exclude>
-            			<exclude>/src/test/resources/fasta_and_pscan.t2flow</exclude>
-            			<exclude>/src/test/resources/fasta_pscan_and_dbfetch.t2flow</exclude>
-            			<exclude>/src/test/resources/interaction-with-strange-loop.t2flow</exclude>
-            			<exclude>/src/test/resources/interaction_multiple_choice.t2flow</exclude>
-            			<exclude>/src/test/resources/interaction_simple_tell.t2flow</exclude>
-            			<exclude>/src/test/resources/iterationstrategies.t2flow</exclude><!-- TOM -->
-            			<exclude>/src/test/resources/merge_fun.t2flow</exclude>
-            			<exclude>/src/test/resources/merge_then_dataflow_link.t2flow</exclude>
-            			<exclude>/src/test/resources/missing_merge.t2flow</exclude>
-            			<exclude>/src/test/resources/missing_produced_by_941.t2flow</exclude>
-            			<exclude>/src/test/resources/rest-2-2.t2flow</exclude>
-            			<exclude>/src/test/resources/rshell-2-2.t2flow</exclude>
-            			<exclude>/src/test/resources/simple_fasta.t2flow</exclude>
-            			<exclude>/src/test/resources/sleepers.t2flow</exclude>
-            			<exclude>/src/test/resources/apiconsumer.t2flow</exclude>
-            			<exclude>/src/test/resources/rest.t2flow</exclude>
-            			<exclude>/src/test/resources/valid_component_imagemagickconvert.t2flow</exclude>
-            			<exclude>/src/test/resources/enm-v21.t2flow</exclude>
-            			<exclude>/src/test/resources/helloworld.wfdesc.ttl</exclude>
-            			<exclude>/src/test/resources/localdependency.t2flow</exclude>
-            			<exclude>/src/test/resources/nested.t2flow</exclude>
-            			<exclude>/src/test/resources/rdf-in-example-annotation.t2flow</exclude>
-            			<exclude>/src/test/resources/workflow10.xml</exclude>
-            			<exclude>/src/test/resources/full-example/ebi_interproscan_newservices_900329.t2flow</exclude>
+						<exclude>/src/test/resources/annotation_with_backslash.t2flow</exclude>
+						<exclude>/src/test/resources/beanshell-deps.t2flow</exclude>
+						<exclude>/src/test/resources/component_simple.t2flow</exclude>
+						<exclude>/src/test/resources/dataflow_link_then_merge.t2flow</exclude>
+						<exclude>/src/test/resources/dispatchlayers-xsd.t2flow</exclude>
+						<exclude>/src/test/resources/dispatchlayers.t2flow</exclude>
+						<exclude>/src/test/resources/fasta_and_pscan.t2flow</exclude>
+						<exclude>/src/test/resources/fasta_pscan_and_dbfetch.t2flow</exclude>
+						<exclude>/src/test/resources/interaction-with-strange-loop.t2flow</exclude>
+						<exclude>/src/test/resources/interaction_multiple_choice.t2flow</exclude>
+						<exclude>/src/test/resources/interaction_simple_tell.t2flow</exclude>
+						<exclude>/src/test/resources/iterationstrategies.t2flow</exclude><!-- TOM -->
+						<exclude>/src/test/resources/merge_fun.t2flow</exclude>
+						<exclude>/src/test/resources/merge_then_dataflow_link.t2flow</exclude>
+						<exclude>/src/test/resources/missing_merge.t2flow</exclude>
+						<exclude>/src/test/resources/missing_produced_by_941.t2flow</exclude>
+						<exclude>/src/test/resources/rest-2-2.t2flow</exclude>
+						<exclude>/src/test/resources/rshell-2-2.t2flow</exclude>
+						<exclude>/src/test/resources/simple_fasta.t2flow</exclude>
+						<exclude>/src/test/resources/sleepers.t2flow</exclude>
+						<exclude>/src/test/resources/apiconsumer.t2flow</exclude>
+						<exclude>/src/test/resources/rest.t2flow</exclude>
+						<exclude>/src/test/resources/valid_component_imagemagickconvert.t2flow</exclude>
+						<exclude>/src/test/resources/enm-v21.t2flow</exclude>
+						<exclude>/src/test/resources/helloworld.wfdesc.ttl</exclude>
+						<exclude>/src/test/resources/localdependency.t2flow</exclude>
+						<exclude>/src/test/resources/nested.t2flow</exclude>
+						<exclude>/src/test/resources/rdf-in-example-annotation.t2flow</exclude>
+						<exclude>/src/test/resources/workflow10.xml</exclude>
+						<exclude>/src/test/resources/full-example/ebi_interproscan_newservices_900329.t2flow</exclude>
 						<!-- Cannot contain comments; content must match program output. -->
 						<exclude>/src/test/resources/org/apache/taverna/scufl2/api/io/HelloWorld.txt</exclude>
 						<exclude>/src/test/resources/as.txt</exclude>
@@ -160,7 +160,7 @@
 								<licenseMerge>Eclipse Public License, Version 1.0|Eclipse Public License</licenseMerge>
 							</licenseMerges>
 						</configuration>
-	                </execution>
+					</execution>
 				</executions>
 			</plugin>
 			-->
@@ -331,7 +331,7 @@
 	<modules>
 		<module>taverna-scufl2-ucfpackage</module>
 		<module>taverna-scufl2-api</module>
-    <module>taverna-scufl2-examples</module>
+		<module>taverna-scufl2-examples</module>
 		<module>taverna-scufl2-rdfxml</module>
 		<module>taverna-scufl2-t2flow</module>
 		<module>taverna-scufl2-scufl</module>

--- a/pom.xml
+++ b/pom.xml
@@ -96,13 +96,10 @@
 						<exclude>/src/test/resources/t172starterpacklist</exclude>
 						<exclude>/src/test/resources/t230starterpacklist</exclude>
 						<!-- THESE ARE XML AND SUPPORT COMMENTS -->
-            			<exclude>/src/test/resources/annotated2.2.t2flow</exclude>
             			<exclude>/src/test/resources/annotation_with_backslash.t2flow</exclude>
-            			<exclude>/src/test/resources/as.t2flow</exclude>
             			<exclude>/src/test/resources/beanshell-deps.t2flow</exclude>
             			<exclude>/src/test/resources/component_simple.t2flow</exclude>
             			<exclude>/src/test/resources/dataflow_link_then_merge.t2flow</exclude>
-            			<exclude>/src/test/resources/defaultActivitiesTaverna2.2.t2flow</exclude>
             			<exclude>/src/test/resources/dispatchlayers-xsd.t2flow</exclude>
             			<exclude>/src/test/resources/dispatchlayers.t2flow</exclude>
             			<exclude>/src/test/resources/fasta_and_pscan.t2flow</exclude>
@@ -110,29 +107,19 @@
             			<exclude>/src/test/resources/interaction-with-strange-loop.t2flow</exclude>
             			<exclude>/src/test/resources/interaction_multiple_choice.t2flow</exclude>
             			<exclude>/src/test/resources/interaction_simple_tell.t2flow</exclude>
-            			<exclude>/src/test/resources/iterationstrategies.t2flow</exclude>
+            			<exclude>/src/test/resources/iterationstrategies.t2flow</exclude><!-- TOM -->
             			<exclude>/src/test/resources/merge_fun.t2flow</exclude>
             			<exclude>/src/test/resources/merge_then_dataflow_link.t2flow</exclude>
             			<exclude>/src/test/resources/missing_merge.t2flow</exclude>
             			<exclude>/src/test/resources/missing_produced_by_941.t2flow</exclude>
-            			<exclude>/src/test/resources/random.t2flow</exclude>
             			<exclude>/src/test/resources/rest-2-2.t2flow</exclude>
             			<exclude>/src/test/resources/rshell-2-2.t2flow</exclude>
-            			<exclude>/src/test/resources/semantic_annotations__eclipse.t2flow</exclude>
             			<exclude>/src/test/resources/simple_fasta.t2flow</exclude>
             			<exclude>/src/test/resources/sleepers.t2flow</exclude>
-            			<exclude>/src/test/resources/spreadsheet_activity_defaults_892.t2flow</exclude>
-            			<exclude>/src/test/resources/T3-1226-annotations-with-quotes.t2flow</exclude>
-            			<exclude>/src/test/resources/xpath_workflow.t2flow</exclude>
-            			<exclude>/examples/helloanyone.t2flow</exclude>
-            			<exclude>/examples/helloworld.t2flow</exclude>
             			<exclude>/src/test/resources/apiconsumer.t2flow</exclude>
             			<exclude>/src/test/resources/rest.t2flow</exclude>
-            			<exclude>/src/test/resources/helloanyone.t2flow</exclude>
             			<exclude>/src/test/resources/valid_component_imagemagickconvert.t2flow</exclude>
-            			<exclude>/src/test/resources/allTypes.t2flow</exclude>
             			<exclude>/src/test/resources/enm-v21.t2flow</exclude>
-            			<exclude>/src/test/resources/helloworld.t2flow</exclude>
             			<exclude>/src/test/resources/helloworld.wfdesc.ttl</exclude>
             			<exclude>/src/test/resources/localdependency.t2flow</exclude>
             			<exclude>/src/test/resources/nested.t2flow</exclude>

--- a/taverna-scufl2-annotation/src/test/resources/helloanyone.t2flow
+++ b/taverna-scufl2-annotation/src/test/resources/helloanyone.t2flow
@@ -1,4 +1,22 @@
 <workflow xmlns="http://taverna.sf.net/2008/xml/t2flow" version="1" producedBy="taverna-2.2.0"><dataflow id="01348671-5aaa-4cc2-84cc-477329b70b0d" role="top"><name>Hello_Anyone</name><inputPorts><port><name>name</name><depth>0</depth><granularDepth>0</granularDepth><annotations><annotation_chain encoding="xstream"><net.sf.taverna.t2.annotation.AnnotationChainImpl xmlns="">
+<!-- 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ -->
   <annotationAssertions>
     <net.sf.taverna.t2.annotation.AnnotationAssertionImpl>
       <annotationBean class="net.sf.taverna.t2.annotation.annotationbeans.ExampleValue">

--- a/taverna-scufl2-examples/examples/helloanyone.t2flow
+++ b/taverna-scufl2-examples/examples/helloanyone.t2flow
@@ -1,3 +1,22 @@
+<?xml version="1.0"?>
+<!-- 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ -->
 <workflow xmlns="http://taverna.sf.net/2008/xml/t2flow" version="1" producedBy="taverna-2.2.0"><dataflow id="01348671-5aaa-4cc2-84cc-477329b70b0d" role="top"><name>Hello_Anyone</name><inputPorts><port><name>name</name><depth>0</depth><granularDepth>0</granularDepth><annotations><annotation_chain encoding="xstream"><net.sf.taverna.t2.annotation.AnnotationChainImpl xmlns="">
   <annotationAssertions>
     <net.sf.taverna.t2.annotation.AnnotationAssertionImpl>

--- a/taverna-scufl2-examples/examples/helloworld.t2flow
+++ b/taverna-scufl2-examples/examples/helloworld.t2flow
@@ -1,3 +1,22 @@
+<?xml version="1.0"?>
+<!-- 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ -->
 <workflow xmlns="http://taverna.sf.net/2008/xml/t2flow" version="1" producedBy="taverna-2.2.0"><dataflow id="8781d5f4-d0ba-48a8-a1d1-14281bd8a917" role="top"><name>Hello_World</name><inputPorts /><outputPorts><port><name>greeting</name><annotations /></port></outputPorts><processors><processor><name>hello</name><inputPorts /><outputPorts><port><name>value</name><depth>0</depth><granularDepth>0</granularDepth></port></outputPorts><annotations /><activities><activity><raven><group>net.sf.taverna.t2.activities</group><artifact>stringconstant-activity</artifact><version>1.2</version></raven><class>net.sf.taverna.t2.activities.stringconstant.StringConstantActivity</class><inputMap /><outputMap><map from="value" to="value" /></outputMap><configBean encoding="xstream"><net.sf.taverna.t2.activities.stringconstant.StringConstantConfigurationBean xmlns="">
   <value>Hello, World!</value>
 </net.sf.taverna.t2.activities.stringconstant.StringConstantConfigurationBean></configBean><annotations /></activity></activities><dispatchStack><dispatchLayer><raven><group>net.sf.taverna.t2.core</group><artifact>workflowmodel-impl</artifact><version>1.2</version></raven><class>net.sf.taverna.t2.workflowmodel.processor.dispatch.layers.Parallelize</class><configBean encoding="xstream"><net.sf.taverna.t2.workflowmodel.processor.dispatch.layers.ParallelizeConfig xmlns="">

--- a/taverna-scufl2-t2flow/src/test/resources/T3-1226-annotations-with-quotes.t2flow
+++ b/taverna-scufl2-t2flow/src/test/resources/T3-1226-annotations-with-quotes.t2flow
@@ -1,3 +1,22 @@
+<?xml version="1.0"?>
+<!-- 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ -->
 <workflow xmlns="http://taverna.sf.net/2008/xml/t2flow" version="1" producedBy="taverna-workbench-core-2.5.0-20140804T1456"><dataflow id="73a04132-5dc0-4e24-8a30-6ef91c773ad1" role="top"><name>T3_1226_test_with__s</name><inputPorts><port><name>a</name><depth>0</depth><granularDepth>0</granularDepth><annotations><annotation_chain encoding="xstream"><net.sf.taverna.t2.annotation.AnnotationChainImpl xmlns="">
   <annotationAssertions>
     <net.sf.taverna.t2.annotation.AnnotationAssertionImpl>

--- a/taverna-scufl2-t2flow/src/test/resources/annotated2.2.t2flow
+++ b/taverna-scufl2-t2flow/src/test/resources/annotated2.2.t2flow
@@ -1,3 +1,22 @@
+<?xml version="1.0"?>
+<!-- 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ -->
 <workflow xmlns="http://taverna.sf.net/2008/xml/t2flow" version="1" producedBy="taverna-2.2.0"><dataflow id="9e1f7ffd-3bf9-4ba8-9c63-03b79b1858ad" role="top"><name>Workflow_title</name><inputPorts><port><name>in0</name><depth>0</depth><granularDepth>0</granularDepth><annotations><annotation_chain encoding="xstream"><net.sf.taverna.t2.annotation.AnnotationChainImpl xmlns="">
   <annotationAssertions>
     <net.sf.taverna.t2.annotation.AnnotationAssertionImpl>

--- a/taverna-scufl2-t2flow/src/test/resources/as.t2flow
+++ b/taverna-scufl2-t2flow/src/test/resources/as.t2flow
@@ -1,4 +1,22 @@
 <workflow xmlns="http://taverna.sf.net/2008/xml/t2flow" version="1" producedBy="taverna-2.1.0">
+<!-- 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ -->
   <dataflow id="92c5e8d5-8360-4f86-a845-09c9849cbdc5" role="top">
     <name>Workflow1</name>
     <inputPorts />

--- a/taverna-scufl2-t2flow/src/test/resources/defaultActivitiesTaverna2.2.t2flow
+++ b/taverna-scufl2-t2flow/src/test/resources/defaultActivitiesTaverna2.2.t2flow
@@ -1,3 +1,22 @@
+<?xml version="1.0"?>
+<!-- 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ -->
 <workflow xmlns="http://taverna.sf.net/2008/xml/t2flow" version="1" producedBy="taverna-2.2.0"><dataflow id="dc227a10-e8f6-44b0-88c5-c946a15ff669" role="top"><name>Workflow1</name><inputPorts /><outputPorts /><processors><processor><name>Beanshell</name><inputPorts /><outputPorts /><annotations /><activities><activity><raven><group>net.sf.taverna.t2.activities</group><artifact>beanshell-activity</artifact><version>1.2</version></raven><class>net.sf.taverna.t2.activities.beanshell.BeanshellActivity</class><inputMap /><outputMap /><configBean encoding="xstream"><net.sf.taverna.t2.activities.beanshell.BeanshellActivityConfigurationBean xmlns="">
   <script>the
 script;</script>

--- a/taverna-scufl2-t2flow/src/test/resources/random.t2flow
+++ b/taverna-scufl2-t2flow/src/test/resources/random.t2flow
@@ -1,3 +1,22 @@
+<?xml version="1.0"?>
+<!-- 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ -->
 <workflow xmlns="http://taverna.sf.net/2008/xml/t2flow" version="1" producedBy="taverna-2.1-beta-2"><dataflow id="e87de19a-02c7-4106-ae81-0b8e28efb22c" role="top"><name>Workflow9</name><inputPorts><port><name>InputText</name><depth>0</depth><granularDepth>0</granularDepth><annotations><annotation_chain encoding="xstream"><net.sf.taverna.t2.annotation.AnnotationChainImpl xmlns="">
   <annotationAssertions>
     <net.sf.taverna.t2.annotation.AnnotationAssertionImpl>

--- a/taverna-scufl2-t2flow/src/test/resources/semantic_annotations__eclipse.t2flow
+++ b/taverna-scufl2-t2flow/src/test/resources/semantic_annotations__eclipse.t2flow
@@ -1,3 +1,22 @@
+<?xml version="1.0"?>
+<!-- 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ -->
 <workflow xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://taverna.sf.net/2008/xml/t2flow ../../main/resources/uk/org/taverna/scufl2/translator/t2flow/xsd/t2flow-extended.xsd "
 	xmlns="http://taverna.sf.net/2008/xml/t2flow" version="1"

--- a/taverna-scufl2-t2flow/src/test/resources/spreadsheet_activity_defaults_892.t2flow
+++ b/taverna-scufl2-t2flow/src/test/resources/spreadsheet_activity_defaults_892.t2flow
@@ -1,3 +1,22 @@
+<?xml version="1.0"?>
+<!-- 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ -->
 <workflow xmlns="http://taverna.sf.net/2008/xml/t2flow" version="1" producedBy="taverna-2.1-beta-2"><dataflow id="d6c01ddf-f1a5-4cb7-95b6-a47ce19838a8" role="top"><name>Workflow1</name><inputPorts><port><name>file_url</name><depth>0</depth><granularDepth>0</granularDepth><annotations /></port></inputPorts><outputPorts><port><name>A_column</name></port><port><name>B_column</name></port></outputPorts><processors><processor><name>SpreadsheetImport</name><inputPorts><port><name>fileurl</name><depth>0</depth></port></inputPorts><outputPorts><port><name>A</name><depth>1</depth><granularDepth>1</granularDepth></port><port><name>B</name><depth>1</depth><granularDepth>1</granularDepth></port></outputPorts><annotations /><activities><activity><raven><group>net.sf.taverna.t2.activities</group><artifact>spreadsheet-import-activity</artifact><version>0.2</version></raven><class>net.sf.taverna.t2.activities.spreadsheet.SpreadsheetImportActivity</class><inputMap><map from="fileurl" to="fileurl" /></inputMap><outputMap><map from="A" to="A" /><map from="B" to="B" /></outputMap><configBean encoding="xstream"><net.sf.taverna.t2.activities.spreadsheet.SpreadsheetImportConfiguration xmlns="">
   <columnRange>
     <start>0</start>

--- a/taverna-scufl2-t2flow/src/test/resources/xpath_workflow.t2flow
+++ b/taverna-scufl2-t2flow/src/test/resources/xpath_workflow.t2flow
@@ -1,3 +1,22 @@
+<?xml version="1.0"?>
+<!-- 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ -->
 <workflow xmlns="http://taverna.sf.net/2008/xml/t2flow" version="1" producedBy="taverna-2.4.0"><dataflow id="1345660e-8b56-407c-9d3f-c2fd3489d26d" role="top"><name>Workflow20</name><inputPorts><port><name>input_file</name><depth>0</depth><granularDepth>0</granularDepth><annotations /></port></inputPorts><outputPorts><port><name>STDERR</name><annotations /></port><port><name>width</name><annotations /></port><port><name>height</name><annotations /></port></outputPorts><processors><processor><name>jpylyzer</name><inputPorts><port><name>input_file</name><depth>0</depth></port></inputPorts><outputPorts><port><name>STDERR</name><depth>0</depth><granularDepth>0</granularDepth></port><port><name>STDOUT</name><depth>0</depth><granularDepth>0</granularDepth></port></outputPorts><annotations /><activities><activity><raven><group>net.sf.taverna.t2.activities</group><artifact>external-tool-activity</artifact><version>1.4</version></raven><class>net.sf.taverna.t2.activities.externaltool.ExternalToolActivity</class><inputMap><map from="input_file" to="input_file" /></inputMap><outputMap><map from="STDERR" to="STDERR" /><map from="STDOUT" to="STDOUT" /></outputMap><configBean encoding="xstream"><net.sf.taverna.t2.activities.externaltool.ExternalToolActivityConfigurationBean xmlns="">
   <mechanismType>789663B8-DA91-428A-9F7D-B3F3DA185FD4</mechanismType>
   <mechanismName>default local</mechanismName>

--- a/taverna-scufl2-wfdesc/src/test/resources/T3-1226-annotations-with-quotes.t2flow
+++ b/taverna-scufl2-wfdesc/src/test/resources/T3-1226-annotations-with-quotes.t2flow
@@ -1,3 +1,22 @@
+<?xml version="1.0"?>
+<!-- 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ -->
 <workflow xmlns="http://taverna.sf.net/2008/xml/t2flow" version="1" producedBy="taverna-workbench-core-2.5.0-20140804T1456"><dataflow id="73a04132-5dc0-4e24-8a30-6ef91c773ad1" role="top"><name>T3_1226_test_with__s</name><inputPorts><port><name>a</name><depth>0</depth><granularDepth>0</granularDepth><annotations><annotation_chain encoding="xstream"><net.sf.taverna.t2.annotation.AnnotationChainImpl xmlns="">
   <annotationAssertions>
     <net.sf.taverna.t2.annotation.AnnotationAssertionImpl>

--- a/taverna-scufl2-wfdesc/src/test/resources/allTypes.t2flow
+++ b/taverna-scufl2-wfdesc/src/test/resources/allTypes.t2flow
@@ -1,4 +1,23 @@
-<workflow xmlns="http://taverna.sf.net/2008/xml/t2flow" version="1" producedBy="taverna-2.4.0"><dataflow id="708f0c31-61b0-4528-a096-9a747e6cdf52" role="top"><name>All_types</name><inputPorts /><outputPorts><port><name>out</name><annotations /></port></outputPorts><processors><processor><name>theWsdl</name><inputPorts><port><name>format</name><depth>0</depth></port><port><name>ids</name><depth>0</depth></port></inputPorts><outputPorts><port><name>attachmentList</name><depth>1</depth><granularDepth>1</granularDepth></port></outputPorts><annotations /><activities><activity><raven><group>net.sf.taverna.t2.activities</group><artifact>wsdl-activity</artifact><version>1.4</version></raven><class>net.sf.taverna.t2.activities.wsdl.WSDLActivity</class><inputMap><map from="ids" to="ids" /><map from="format" to="format" /></inputMap><outputMap><map from="attachmentList" to="attachmentList" /></outputMap><configBean encoding="xstream"><net.sf.taverna.t2.activities.wsdl.WSDLActivityConfigurationBean xmlns="">
+<workflow xmlns="http://taverna.sf.net/2008/xml/t2flow" version="1" producedBy="taverna-2.4.0">
+<!-- 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ -->
+<dataflow id="708f0c31-61b0-4528-a096-9a747e6cdf52" role="top"><name>All_types</name><inputPorts /><outputPorts><port><name>out</name><annotations /></port></outputPorts><processors><processor><name>theWsdl</name><inputPorts><port><name>format</name><depth>0</depth></port><port><name>ids</name><depth>0</depth></port></inputPorts><outputPorts><port><name>attachmentList</name><depth>1</depth><granularDepth>1</granularDepth></port></outputPorts><annotations /><activities><activity><raven><group>net.sf.taverna.t2.activities</group><artifact>wsdl-activity</artifact><version>1.4</version></raven><class>net.sf.taverna.t2.activities.wsdl.WSDLActivity</class><inputMap><map from="ids" to="ids" /><map from="format" to="format" /></inputMap><outputMap><map from="attachmentList" to="attachmentList" /></outputMap><configBean encoding="xstream"><net.sf.taverna.t2.activities.wsdl.WSDLActivityConfigurationBean xmlns="">
   <wsdl>http://www.ebi.ac.uk/ws/services/urn:Dbfetch?wsdl</wsdl>
   <operation>fetchBatch</operation>
 </net.sf.taverna.t2.activities.wsdl.WSDLActivityConfigurationBean></configBean><annotations /></activity></activities><dispatchStack><dispatchLayer><raven><group>net.sf.taverna.t2.core</group><artifact>workflowmodel-impl</artifact><version>1.4</version></raven><class>net.sf.taverna.t2.workflowmodel.processor.dispatch.layers.Parallelize</class><configBean encoding="xstream"><net.sf.taverna.t2.workflowmodel.processor.dispatch.layers.ParallelizeConfig xmlns="">

--- a/taverna-scufl2-wfdesc/src/test/resources/helloanyone.t2flow
+++ b/taverna-scufl2-wfdesc/src/test/resources/helloanyone.t2flow
@@ -1,3 +1,22 @@
+<?xml version="1.0"?>
+<!-- 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ -->
 <workflow xmlns="http://taverna.sf.net/2008/xml/t2flow" version="1" producedBy="taverna-2.2.0"><dataflow id="01348671-5aaa-4cc2-84cc-477329b70b0d" role="top"><name>Hello_Anyone</name><inputPorts><port><name>name</name><depth>0</depth><granularDepth>0</granularDepth><annotations><annotation_chain encoding="xstream"><net.sf.taverna.t2.annotation.AnnotationChainImpl xmlns="">
   <annotationAssertions>
     <net.sf.taverna.t2.annotation.AnnotationAssertionImpl>

--- a/taverna-scufl2-wfdesc/src/test/resources/helloworld.t2flow
+++ b/taverna-scufl2-wfdesc/src/test/resources/helloworld.t2flow
@@ -1,3 +1,22 @@
+<?xml version="1.0"?>
+<!-- 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ -->
 <workflow xmlns="http://taverna.sf.net/2008/xml/t2flow" version="1" producedBy="taverna-2.2.0"><dataflow id="8781d5f4-d0ba-48a8-a1d1-14281bd8a917" role="top"><name>Hello_World</name><inputPorts /><outputPorts><port><name>greeting</name><annotations /></port></outputPorts><processors><processor><name>hello</name><inputPorts /><outputPorts><port><name>value</name><depth>0</depth><granularDepth>0</granularDepth></port></outputPorts><annotations /><activities><activity><raven><group>net.sf.taverna.t2.activities</group><artifact>stringconstant-activity</artifact><version>1.2</version></raven><class>net.sf.taverna.t2.activities.stringconstant.StringConstantActivity</class><inputMap /><outputMap><map from="value" to="value" /></outputMap><configBean encoding="xstream"><net.sf.taverna.t2.activities.stringconstant.StringConstantConfigurationBean xmlns="">
   <value>Hello, World!</value>
 </net.sf.taverna.t2.activities.stringconstant.StringConstantConfigurationBean></configBean><annotations /></activity></activities><dispatchStack><dispatchLayer><raven><group>net.sf.taverna.t2.core</group><artifact>workflowmodel-impl</artifact><version>1.2</version></raven><class>net.sf.taverna.t2.workflowmodel.processor.dispatch.layers.Parallelize</class><configBean encoding="xstream"><net.sf.taverna.t2.workflowmodel.processor.dispatch.layers.ParallelizeConfig xmlns="">


### PR DESCRIPTION
Tiny update that gets rid of more wildcards in the RAT config
